### PR TITLE
Perf: replace the uniform lock with separate locks for each document index object

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 [在线体验](https://simpleui.72wo.com/search/simpleui)
 
 ## GoFound在线管理后台Demo
+
 [http://119.29.69.50:5678/admin](http://119.29.69.50:5678/admin)
 
 ![](./docs/images/img1.png)
@@ -51,15 +52,12 @@
 ### 为何要用golang实现一个全文检索引擎？
 
 + 正如其名，`GoFound`去探索全文检索的世界，一个小巧精悍的全文检索引擎，支持持久化和单机亿级数据毫秒级查找。
-
 + 传统的项目大多数会采用`ElasticSearch`来做全文检索，因为`ElasticSearch`够成熟，社区活跃、资料完善。缺点就是配置繁琐、基于JVM对内存消耗比较大。
-
 + 所以我们需要一个更高效的搜索引擎，而又不会消耗太多的内存。 以最低的内存达到全文检索的目的，相比`ElasticSearch`，`gofound`是原生编译，会减少系统资源的消耗。而且对外无任何依赖。
 
 ## 安装和启动
 
 > 下载好源码之后，进入到源码目录，执行下列两个命令
->
 
 + 编译
 
@@ -99,16 +97,16 @@ docker run -d --name gofound -p 5678:5678 -v /mnt/data/gofound:/usr/local/go_fou
 
 ## 和ES比较
 
-| ES          | GoFound               |
-|-------------|-----------------------|
-| 支持持久化       | 支持持久化                 |
-| 基于内存索引      | 基于磁盘+内存缓存             |
-| 需要安装JDK     | 原生二进制，无外部依赖           |
-| 需要安装第三方分词插件 | 自带中文分词和词库             |
-| 默认没有可视化管理界面 | 自带可视化管理界面             |
-| 内存占用大       | 基于Golang原生可执行文件，内存非常小 |
-| 配置复杂        | 默认可以不加任何参数启动，并且提供少量配置 |
 
+| ES                     | GoFound                                    |
+| ---------------------- | ------------------------------------------ |
+| 支持持久化             | 支持持久化                                 |
+| 基于内存索引           | 基于磁盘+内存缓存                          |
+| 需要安装JDK            | 原生二进制，无外部依赖                     |
+| 需要安装第三方分词插件 | 自带中文分词和词库                         |
+| 默认没有可视化管理界面 | 自带可视化管理界面                         |
+| 内存占用大             | 基于Golang原生可执行文件，内存非常小       |
+| 配置复杂               | 默认可以不加任何参数启动，并且提供少量配置 |
 
 ## 待办
 
@@ -131,9 +129,11 @@ docker run -d --name gofound -p 5678:5678 -v /mnt/data/gofound:/usr/local/go_fou
 [发布日志](https://github.com/newpanjing/gofound/releases)
 
 ## 开发成员
-|姓名|联系方式|贡献部分|
-|---|---|---|
-|[XiaoK29](https://github.com/XiaoK29)|1526783667@qq.com|负责人、引擎、接口|
-|[newpanjing](https://github.com/newpanjing)|newpanjing@icloud.com|引擎、UI|
-|[nightzjp](https://github.com/nightzjp)|-|引擎|
-|[xiao luobei](https://github.com/liu-cn)|-|引擎|
+
+
+| 姓名                                        | 联系方式              | 贡献部分           |
+| ------------------------------------------- | --------------------- | ------------------ |
+| [XiaoK29](https://github.com/XiaoK29)       | 1526783667@qq.com     | 负责人、引擎、接口 |
+| [newpanjing](https://github.com/newpanjing) | newpanjing@icloud.com | 引擎、UI           |
+| [nightzjp](https://github.com/nightzjp)     | -                     | 引擎               |
+| [xiao luobei](https://github.com/liu-cn)    | -                     | 引擎               |

--- a/searcher/arrays/arrays.go
+++ b/searcher/arrays/arrays.go
@@ -23,14 +23,12 @@ func BinarySearch(arr []uint32, target uint32) bool {
 }
 
 func ArrayStringExists(arr []string, str string) bool {
-
 	for _, v := range arr {
 		if v == str {
 			return true
 		}
 	}
 	return false
-
 }
 
 // MergeArrayUint32 合并两个数组

--- a/searcher/engine.go
+++ b/searcher/engine.go
@@ -247,7 +247,7 @@ func (e *Engine) optimizeIndex(id uint32, newWords []string) ([]string, bool) {
 	removes, inserts, changed := e.getDifference(id, newWords)
 	if changed {
 		if removes != nil && len(removes) > 0 {
-			// 移除正排索引
+			// 移除倒排索引
 			for _, word := range removes {
 				e.removeIdInWordIndex(id, word)
 			}

--- a/tests/benchmark/array_test.go
+++ b/tests/benchmark/array_test.go
@@ -1,9 +1,14 @@
 package benchmark
 
 import (
+	"github.com/emirpasic/gods/sets/hashset"
 	"gofound/searcher/arrays"
+	"math/rand"
+	"sort"
 	"testing"
 )
+
+const dir = "abcdefghijklmnopqrstuvwxyzABCDEFGXIJKLMNOPQRSTUVWXYZ1234567890"
 
 func Benchmark(b *testing.B) {
 
@@ -43,4 +48,67 @@ func Benchmark(b *testing.B) {
 			}
 		}
 	})
+}
+
+/*
+*
+string array length = 10000, single string length = 15
+BenchmarkArrayStringExists
+BenchmarkArrayStringExists-6    	1000000000	         0.0000568 ns/op
+BenchmarkArrayStringExists1
+BenchmarkArrayStringExists1-6   	1000000000	         0.002870 ns/op
+
+string array length = 1000000, single string length = 15
+BenchmarkArrayStringExists
+BenchmarkArrayStringExists-6    	1000000000	         0.0007200 ns/op
+BenchmarkArrayStringExists1
+BenchmarkArrayStringExists1-6   	       1	1029444051 ns/op
+*/
+func BenchmarkArrayStringExists(b *testing.B) {
+	path := hashset.New()
+	s := make([]string, 0)
+	for i := 0; i < 1000000; i++ {
+		p := ""
+		for j := 0; j < 15; j++ {
+			p += string(dir[rand.Intn(len(dir))])
+		}
+		for path.Contains(p) {
+			for j := 0; j < 15; j++ {
+				p += string(dir[rand.Intn(len(dir))])
+			}
+		}
+		path.Add(p)
+		s = append(s, p)
+	}
+	b.ResetTimer()
+	arrays.ArrayStringExists(s, s[rand.Intn(len(s))])
+}
+
+func BenchmarkArrayStringExists1(b *testing.B) {
+	path := hashset.New()
+	s := make([]string, 0)
+	for i := 0; i < 1000000; i++ {
+		p := ""
+		for j := 0; j < 15; j++ {
+			p += string(dir[rand.Intn(len(dir))])
+		}
+		for path.Contains(p) {
+			for j := 0; j < 15; j++ {
+				p += string(dir[rand.Intn(len(dir))])
+			}
+		}
+		path.Add(p)
+		s = append(s, p)
+	}
+	b.ResetTimer()
+	arrayStringExists2(s, s[rand.Intn(len(s))])
+}
+
+func arrayStringExists2(arr []string, str string) bool {
+	sort.Strings(arr)
+	index := sort.SearchStrings(arr, str)
+	if index < len(arr) && arr[index] == str {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
使用对象锁替换操作倒排索引时的全局锁，提高性能
数据量1k，text在100-1200字符间，id随机1-2147483647。
明显加快了添加索引的速度，但是频繁的加锁解锁会导致cpu过高
- 优化前
![1667283361540](https://user-images.githubusercontent.com/75628309/199170925-fa81b87a-2f9c-4c18-b3fd-d325202fc54f.jpg)
![3c2f83c0c54e4150e2828f6346d3952](https://user-images.githubusercontent.com/75628309/199171057-a955a943-8278-401e-b45b-dc830963d603.jpg)

- 优化后
![1667283361534](https://user-images.githubusercontent.com/75628309/199171037-df2b06e4-80ae-410b-b726-6b3982863bd1.jpg)
![167d1094443d7ec80dc9758f640d2ba](https://user-images.githubusercontent.com/75628309/199171065-9d29b62b-ea27-4d78-92df-1eaa608a06cf.jpg)

对于添加新的索引，在数据量较大时，可以看出添加索引的瓶颈在leveldb的读写和编解码上
![image](https://user-images.githubusercontent.com/75628309/199180357-883cb4ce-bdc4-48e7-84d1-d8a34b0e6d42.png)


